### PR TITLE
Updates to L3 processor to handle a dependency input file

### DIFF
--- a/imap_l3_data_processor.py
+++ b/imap_l3_data_processor.py
@@ -50,6 +50,16 @@ def _convert_to_datetime(date):
 
 def imap_l3_processor():
     args = _parse_cli_arguments()
+
+    # If the dependency argument was passed in as a json file, read it into a string
+    if args.dependency.endswith(".json"):
+        logger.info(
+            f"Interpreting dependency argument as a JSON file: {args.dependency}"
+        )
+        dependency_filepath = imap_data_access.download(args.dependency)
+        with open(dependency_filepath) as f:
+            args.dependency = f.read()
+
     processing_input_collection = ProcessingInputCollection()
     processing_input_collection.deserialize(args.dependency)
 


### PR DESCRIPTION
# Change Summary
We updated infrastructure to pass in dependencies as part of a JSON file. This change is an example for how to update the processing code to use a file instead of a string. 

This is a fix for some of the SIT-4 bugs we found, and to line up with the dependency output again.  

## Overview
<!--Add a list or paragraph giving an overview of your changes-->
Since the file contains the same expected string, we just need to download and open the file if it's passed in. 

## Testing
<!--List any relevant testing information like number of unit tests added, any new tests being skipped and the reason why, etc.-->
I didn't update any unit tests - the existing ones should work as there is an if statement check, so the previous way of handling things still works. 