### PR TITLE
JNIE - Fix CoDICE Hi L3a DE test

### DIFF
--- a/tests/codice/l3/hi/test_models.py
+++ b/tests/codice/l3/hi/test_models.py
@@ -258,7 +258,7 @@ class TestModels(unittest.TestCase):
             old_label_attrs = expanded_cdf["priority_label"].attrs
             del expanded_cdf["priority_label"]
             expanded_cdf["priority_label"] = [f"Priority {i}" for i in range(8)]
-            expanded_cdf["priority_label"] = old_label_attrs
+            expanded_cdf["priority_label"].attrs = old_label_attrs
 
             event_based_vars = [
                 "data_quality",


### PR DESCRIPTION
A CoDICE Hi L3a direct event test was failing with a failure to read from the filesystem.

```python
expanded_cdf["priority_label"] = [f"Priority {i}" for i in range(8)]
expanded_cdf["priority_label"] = old_label_attrs  # failed
```
Looks like the second line was probably supposed to assign to `expanded_cdf["priority_label"].attrs`; made that fix and it works.
