### PR TITLE
Metadata fixes for CoDICE L3a sw-charge-state-distribution

### DIFF
--- a/imap_l3_processing/cdf/config/imap_codice_l3a_hi-direct-events_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_hi-direct-events_variable_attrs.yaml
@@ -7,7 +7,6 @@ primary_data_variable: &primary_data_variable
 
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   RECORD_VARYING: NRV
 
 float_data: &float_data

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-direct-events_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-direct-events_variable_attrs.yaml
@@ -10,7 +10,6 @@ primary_data_variable: &primary_data_variable
 
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   RECORD_VARYING: NRV
 
 float_data: &float_data

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-heplus-3d-distribution_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-heplus-3d-distribution_variable_attrs.yaml
@@ -1,6 +1,5 @@
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   RECORD_VARYING: NRV
 
 float_data: &float_data

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-heplusplus-3d-distribution_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-heplusplus-3d-distribution_variable_attrs.yaml
@@ -1,6 +1,5 @@
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   RECORD_VARYING: NRV
 
 float_data: &float_data

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-hplus-3d-distribution_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-hplus-3d-distribution_variable_attrs.yaml
@@ -1,6 +1,5 @@
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   RECORD_VARYING: NRV
 
 float_data: &float_data

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-oplus6-3d-distribution_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-oplus6-3d-distribution_variable_attrs.yaml
@@ -1,6 +1,5 @@
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   RECORD_VARYING: NRV
 
 float_data: &float_data

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-partial-densities_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-partial-densities_variable_attrs.yaml
@@ -7,7 +7,6 @@ primary_data_variable: &primary_data_variable
 
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   DEPEND_0: epoch
   RECORD_VARYING: RV
 

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-sw-charge-state-distributions_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-sw-charge-state-distributions_variable_attrs.yaml
@@ -86,8 +86,8 @@ carbon_charge_state_distribution:
 
 carbon_charge_state:
   NAME: carbon_charge_state
+  CATDESC: Carbon charge state
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   DATA_TYPE: CDF_INT1
   FIELDNAM: C Charge
   LABLAXIS: C Charge
@@ -101,8 +101,8 @@ carbon_charge_state:
 
 oxygen_charge_state:
   NAME: oxygen_charge_state
+  CATDESC: Oxygen charge state
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   DATA_TYPE: CDF_INT1
   FIELDNAM: O Charge
   LABLAXIS: O Charge

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-sw-charge-state-distributions_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-sw-charge-state-distributions_variable_attrs.yaml
@@ -7,7 +7,6 @@ primary_data_variable: &primary_data_variable
 
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   DEPEND_0: epoch
   RECORD_VARYING: RV
 

--- a/imap_l3_processing/cdf/config/imap_codice_l3a_lo-sw-ratios_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_codice_l3a_lo-sw-ratios_variable_attrs.yaml
@@ -7,7 +7,6 @@ primary_data_variable: &primary_data_variable
 
 support_data: &support_data
   VAR_TYPE: support_data
-  DISPLAY_TYPE: no_plot
   DEPEND_0: epoch
   RECORD_VARYING: RV
 


### PR DESCRIPTION
# Change Summary

## Overview

Adds CATDESC to the charge state variables (the DEPEND_1 support_data); remove the plot_type as not needed for support_data.

Removed the support_data plot_type for all CoDICE L3 products.

@pleasant-menlo , is CAVA expecting plot_type for support_data?