### PR TITLE
Fix GLOWS L3d FORMAT to account for IDL

### DIFF
--- a/imap_l3_processing/cdf/config/imap_glows_l3d_variable_attrs.yaml
+++ b/imap_l3_processing/cdf/config/imap_glows_l3d_variable_attrs.yaml
@@ -128,7 +128,7 @@ phion:
   RECORD_VARYING: RV
   VARIABLE_PURPOSE: PRIMARY_VAR,SUMMARY
   FIELDNAM: Photoionization Rate
-  FORMAT: E6.1E2
+  FORMAT: E7.1E2
   LABLAXIS: Photoionization rate
   DISPLAY_TYPE: time_series
   UNITS: '#/s'


### PR DESCRIPTION
SPDF points out that IDL always uses two digits + sign for the exponent. GLOWS L3d phion had FORMAT E6.1E2. But IDL requires three characters for the exponent, so need E7.
