### PR TITLE
SWAPI: Flag alpha fits with out-of-range proton-to-alpha peak ratios

### DIFF
--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -66,7 +66,10 @@ J^{\alpha}
 Some notes on error handling:
 - If the proton fit fails, fill values are reported and the proton quality flag is propagated.
 - If the alpha fit fails at any point, fill values are reported and `FIT_ERROR` is set.
+- If the ratio of the fitted alpha and proton model peak energies per charge is outside the range configured by `MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO` and `MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO`, fill values are reported and `BAD_FIT` is set.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
+
+The proton and alpha peak locations are calculated from their separate forward-model coincidence-rate curves over the full coarse ESA grid. Both component curves include the deadtime correction from their combined rate and are averaged over the five sweeps before their maxima are located.
 
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.
 

--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -66,7 +66,7 @@ J^{\alpha}
 Some notes on error handling:
 - If the proton fit fails, fill values are reported and the proton quality flag is propagated.
 - If the alpha fit fails at any point, fill values are reported and `FIT_ERROR` is set.
-- If the ratio of the fitted alpha and proton peak energies per charge is less than 1.7, fill values are reported and `BAD_FIT` is set. There is no upper limit.
+- If the ratio of the fitted alpha and proton peak energies per charge (inferred from the fitted bulk speeds) is less than 1.7, fill values are reported and `BAD_FIT` is set. There is currently no upper limit.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
 
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.

--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -69,15 +69,6 @@ Some notes on error handling:
 - If the ratio of the fitted alpha and proton peak energies per charge is less than 1.7, fill values are reported and `BAD_FIT` is set. There is no upper limit.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
 
-The approximate peak-energy ratio is calculated directly from the fitted bulk velocity magnitudes:
-```math
-\frac{(E/q)_{\alpha}}{(E/q)_{p}}
-= \frac{m_{\alpha}/q_{\alpha}}{m_{p}/q_{p}}
-  \frac{|\mathbf{v}^{\alpha}|^{2}}{|\mathbf{v}^{p}|^{2}}
-\approx 2\frac{|\mathbf{v}^{\alpha}|^{2}}{|\mathbf{v}^{p}|^{2}},
-```
-where an alpha particle has approximately twice the mass per charge of a proton.
-
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.
 
 

--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -66,10 +66,17 @@ J^{\alpha}
 Some notes on error handling:
 - If the proton fit fails, fill values are reported and the proton quality flag is propagated.
 - If the alpha fit fails at any point, fill values are reported and `FIT_ERROR` is set.
-- If the ratio of the fitted alpha and proton model peak energies per charge is outside the range configured by `MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO` and `MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO`, fill values are reported and `BAD_FIT` is set.
+- If the ratio of the fitted alpha and proton peak energies per charge is less than 1.7, fill values are reported and `BAD_FIT` is set. There is no upper limit.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
 
-The proton and alpha peak locations are calculated from their separate forward-model coincidence-rate curves over the full coarse ESA grid. Both component curves include the deadtime correction from their combined rate and are averaged over the five sweeps before their maxima are located.
+The approximate peak-energy ratio is calculated directly from the fitted bulk velocity magnitudes:
+```math
+\frac{(E/q)_{\alpha}}{(E/q)_{p}}
+= \frac{m_{\alpha}/q_{\alpha}}{m_{p}/q_{p}}
+  \frac{|\mathbf{v}^{\alpha}|^{2}}{|\mathbf{v}^{p}|^{2}}
+\approx 2\frac{|\mathbf{v}^{\alpha}|^{2}}{|\mathbf{v}^{p}|^{2}},
+```
+where an alpha particle has approximately twice the mass per charge of a proton.
 
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.
 

--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -66,7 +66,7 @@ J^{\alpha}
 Some notes on error handling:
 - If the proton fit fails, fill values are reported and the proton quality flag is propagated.
 - If the alpha fit fails at any point, fill values are reported and `FIT_ERROR` is set.
-- If the fitted alpha bulk speed is less than 90% of the fitted proton bulk speed, fill values are reported and `BAD_FIT` is set. This guards against the proton shoulder being confused for the alpha population.
+- If the fitted alpha bulk speed is less than 90% of the fitted proton bulk speed, fill values are reported and `BAD_FIT` is set. This is intended to avoid confusing the proton beam population for the alpha population.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
 
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.

--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -66,7 +66,7 @@ J^{\alpha}
 Some notes on error handling:
 - If the proton fit fails, fill values are reported and the proton quality flag is propagated.
 - If the alpha fit fails at any point, fill values are reported and `FIT_ERROR` is set.
-- If the ratio of the fitted alpha and proton peak energies per charge (inferred from the fitted bulk speeds) is less than 1.7, fill values are reported and `BAD_FIT` is set. There is currently no upper limit.
+- If the ratio of the fitted alpha and proton peak energies per charge (inferred from the fitted bulk speeds) is less than 1.7, fill values are reported and `BAD_FIT` is set.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
 
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.

--- a/docs/swapi/alpha-sw.md
+++ b/docs/swapi/alpha-sw.md
@@ -66,7 +66,7 @@ J^{\alpha}
 Some notes on error handling:
 - If the proton fit fails, fill values are reported and the proton quality flag is propagated.
 - If the alpha fit fails at any point, fill values are reported and `FIT_ERROR` is set.
-- If the ratio of the fitted alpha and proton peak energies per charge (inferred from the fitted bulk speeds) is less than 1.7, fill values are reported and `BAD_FIT` is set.
+- If the fitted alpha bulk speed is less than 90% of the fitted proton bulk speed, fill values are reported and `BAD_FIT` is set. This guards against the proton shoulder being confused for the alpha population.
 - If the alpha fit converges but $`R^{2} < 0.9`$, fill values are reported and `BAD_FIT` is set.
 
 `R^{2}`$ is computed using the sweep-averaged coincidence rate for the points used in the alpha fit.

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -36,7 +36,7 @@ from imap_l3_processing.swapi.response.deadtime import deadtime_factor
 # reject alpha fits where the speed is less than 90% of
 # the proton speed, to avoid cases where the proton shoulder
 # is confused for the alpha population
-TOLERABLE_ALPHA_SPEED_RATIO = 0.9
+MIN_TOLERABLE_ALPHA_SPEED_RATIO = 0.9
 
 
 @dataclass
@@ -165,7 +165,7 @@ def _construct_alpha_fit_result(
         np.linalg.norm(velocity_rtn, axis=-1)
         / np.linalg.norm(proton_bulk, axis=-1)
     )
-    if speed_ratio < TOLERABLE_ALPHA_SPEED_RATIO:
+    if speed_ratio < MIN_TOLERABLE_ALPHA_SPEED_RATIO:
         return _nan_alpha_fit_result(bad_fit_flag | SwapiL3Flags.BAD_FIT)
 
     fit_r_squared = _alpha_r_squared(

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -6,7 +6,6 @@ import scipy.optimize
 from numpy import ndarray
 from uncertainties import UFloat, covariance_matrix, ufloat
 
-from imap_l3_processing.swapi.constants import SWAPI_K_FACTOR
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.calculate_initial_guess import (
     calculate_initial_guess,
 )
@@ -34,7 +33,6 @@ from imap_l3_processing.swapi.quality_flags import SwapiL3Flags
 from imap_l3_processing.swapi.response.deadtime import deadtime_factor
 
 MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO = 1.7
-MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO = 2.3
 
 
 @dataclass
@@ -121,8 +119,6 @@ def fit_solar_wind_alpha_model(
     return _construct_alpha_fit_result(
         result=result,
         alpha_ctx_peak=alpha_ctx_peak,
-        alpha_ctx=alpha_ctx,
-        proton_true_rate=proton_true_rate,
         n_peak_bins=peak_bin_idx.size,
         n_sweeps=n_sweeps,
         proton_moments=proton_moments,
@@ -146,8 +142,6 @@ def _nan_alpha_fit_result(flag: int) -> AlphaSolarWindFitResult:
 def _construct_alpha_fit_result(
     result: scipy.optimize.OptimizeResult,
     alpha_ctx_peak: SolarWindFitContext,
-    alpha_ctx: SolarWindFitContext,
-    proton_true_rate: ndarray,
     n_peak_bins: int,
     n_sweeps: int,
     proton_moments: ProtonSolarWindFitResult,
@@ -163,24 +157,12 @@ def _construct_alpha_fit_result(
     delta_v_fit = float(result.x[2])
     velocity_rtn = proton_bulk + delta_v_fit * magnetic_field_direction
 
-    alpha_true_rate, _ = model_solar_wind_ideal_coincidence_rates(
-        SolarWindParams(
-            density=alpha_density_fit,
-            velocity_rtn=velocity_rtn,
-            temperature=alpha_temperature_fit,
-            mass=alpha_ctx.mass_kg,
-        ),
-        alpha_ctx,
-    )
-    peak_energy_ratio = _modeled_alpha_to_proton_peak_energy_ratio(
-        proton_true_rate=proton_true_rate,
-        alpha_true_rate=alpha_true_rate,
-        esa_voltage=alpha_ctx.esa_voltage,
-    )
-    if not (
-        MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO
-        <= peak_energy_ratio
-        <= MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO
+    peak_energy_ratio = 2 * (
+        np.linalg.norm(velocity_rtn) / np.linalg.norm(proton_bulk)
+    ) ** 2
+    if (
+        not np.isfinite(peak_energy_ratio)
+        or peak_energy_ratio < MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO
     ):
         return _nan_alpha_fit_result(bad_fit_flag | SwapiL3Flags.BAD_FIT)
 
@@ -223,25 +205,6 @@ def _alpha_r_squared(
         residuals.reshape(n_sweeps, n_peak_bins), axis=0
     )
     return r_squared(averaged_residual, averaged_count_rate)
-
-
-def _modeled_alpha_to_proton_peak_energy_ratio(
-    proton_true_rate: ndarray,
-    alpha_true_rate: ndarray,
-    esa_voltage: ndarray,
-) -> float:
-    """Return the alpha/proton fitted-curve peak ratio in the E/q domain."""
-    total_true_rate = proton_true_rate + alpha_true_rate
-    deadtime = deadtime_factor(total_true_rate)
-    proton_rate = (proton_true_rate * deadtime).reshape(esa_voltage.shape)
-    alpha_rate = (alpha_true_rate * deadtime).reshape(esa_voltage.shape)
-    proton_rate_avg = np.mean(proton_rate, axis=0)
-    alpha_rate_avg = np.mean(alpha_rate, axis=0)
-    energy_per_charge_avg = SWAPI_K_FACTOR * np.mean(np.abs(esa_voltage), axis=0)
-
-    proton_peak_energy = energy_per_charge_avg[np.argmax(proton_rate_avg)]
-    alpha_peak_energy = energy_per_charge_avg[np.argmax(alpha_rate_avg)]
-    return float(alpha_peak_energy / proton_peak_energy)
 
 
 class _AlphaEvaluator:

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -6,6 +6,7 @@ import scipy.optimize
 from numpy import ndarray
 from uncertainties import UFloat, covariance_matrix, ufloat
 
+from imap_l3_processing.swapi.constants import SWAPI_K_FACTOR
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.calculate_initial_guess import (
     calculate_initial_guess,
 )
@@ -31,6 +32,9 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.uncertainties import (
 )
 from imap_l3_processing.swapi.quality_flags import SwapiL3Flags
 from imap_l3_processing.swapi.response.deadtime import deadtime_factor
+
+MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO = 1.7
+MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO = 2.3
 
 
 @dataclass
@@ -117,6 +121,8 @@ def fit_solar_wind_alpha_model(
     return _construct_alpha_fit_result(
         result=result,
         alpha_ctx_peak=alpha_ctx_peak,
+        alpha_ctx=alpha_ctx,
+        proton_true_rate=proton_true_rate,
         n_peak_bins=peak_bin_idx.size,
         n_sweeps=n_sweeps,
         proton_moments=proton_moments,
@@ -140,6 +146,8 @@ def _nan_alpha_fit_result(flag: int) -> AlphaSolarWindFitResult:
 def _construct_alpha_fit_result(
     result: scipy.optimize.OptimizeResult,
     alpha_ctx_peak: SolarWindFitContext,
+    alpha_ctx: SolarWindFitContext,
+    proton_true_rate: ndarray,
     n_peak_bins: int,
     n_sweeps: int,
     proton_moments: ProtonSolarWindFitResult,
@@ -154,6 +162,27 @@ def _construct_alpha_fit_result(
     alpha_temperature_fit = float(np.exp(result.x[1]))
     delta_v_fit = float(result.x[2])
     velocity_rtn = proton_bulk + delta_v_fit * magnetic_field_direction
+
+    alpha_true_rate, _ = model_solar_wind_ideal_coincidence_rates(
+        SolarWindParams(
+            density=alpha_density_fit,
+            velocity_rtn=velocity_rtn,
+            temperature=alpha_temperature_fit,
+            mass=alpha_ctx.mass_kg,
+        ),
+        alpha_ctx,
+    )
+    peak_energy_ratio = _modeled_alpha_to_proton_peak_energy_ratio(
+        proton_true_rate=proton_true_rate,
+        alpha_true_rate=alpha_true_rate,
+        esa_voltage=alpha_ctx.esa_voltage,
+    )
+    if not (
+        MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO
+        <= peak_energy_ratio
+        <= MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO
+    ):
+        return _nan_alpha_fit_result(bad_fit_flag | SwapiL3Flags.BAD_FIT)
 
     fit_r_squared = _alpha_r_squared(
         residuals=result.fun,
@@ -194,6 +223,25 @@ def _alpha_r_squared(
         residuals.reshape(n_sweeps, n_peak_bins), axis=0
     )
     return r_squared(averaged_residual, averaged_count_rate)
+
+
+def _modeled_alpha_to_proton_peak_energy_ratio(
+    proton_true_rate: ndarray,
+    alpha_true_rate: ndarray,
+    esa_voltage: ndarray,
+) -> float:
+    """Return the alpha/proton fitted-curve peak ratio in the E/q domain."""
+    total_true_rate = proton_true_rate + alpha_true_rate
+    deadtime = deadtime_factor(total_true_rate)
+    proton_rate = (proton_true_rate * deadtime).reshape(esa_voltage.shape)
+    alpha_rate = (alpha_true_rate * deadtime).reshape(esa_voltage.shape)
+    proton_rate_avg = np.mean(proton_rate, axis=0)
+    alpha_rate_avg = np.mean(alpha_rate, axis=0)
+    energy_per_charge_avg = SWAPI_K_FACTOR * np.mean(np.abs(esa_voltage), axis=0)
+
+    proton_peak_energy = energy_per_charge_avg[np.argmax(proton_rate_avg)]
+    alpha_peak_energy = energy_per_charge_avg[np.argmax(alpha_rate_avg)]
+    return float(alpha_peak_energy / proton_peak_energy)
 
 
 class _AlphaEvaluator:

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -159,12 +159,10 @@ def _construct_alpha_fit_result(
     velocity_rtn = proton_bulk + delta_v_fit * magnetic_field_direction
 
     peak_energy_ratio = ALPHA_MASS_PER_CHARGE_M_P_PER_E * (
-        np.linalg.norm(velocity_rtn) / np.linalg.norm(proton_bulk)
+        np.linalg.norm(velocity_rtn, axis=-1)
+        / np.linalg.norm(proton_bulk, axis=-1)
     ) ** 2
-    if (
-        not np.isfinite(peak_energy_ratio)
-        or peak_energy_ratio < MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO
-    ):
+    if peak_energy_ratio < MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO:
         return _nan_alpha_fit_result(bad_fit_flag | SwapiL3Flags.BAD_FIT)
 
     fit_r_squared = _alpha_r_squared(

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -161,12 +161,11 @@ def _construct_alpha_fit_result(
     delta_v_fit = float(result.x[2])
     velocity_rtn = proton_bulk + delta_v_fit * magnetic_field_direction
 
-    peak_energy_ratio = ALPHA_MASS_PER_CHARGE_M_P_PER_E * (
+    speed_ratio = (
         np.linalg.norm(velocity_rtn, axis=-1)
         / np.linalg.norm(proton_bulk, axis=-1)
-    ) ** 2
-    # convert energy-per-charge to speed for comparison
-    if np.sqrt(peak_energy_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E) < TOLERABLE_ALPHA_SPEED_RATIO:
+    )
+    if speed_ratio < TOLERABLE_ALPHA_SPEED_RATIO:
         return _nan_alpha_fit_result(bad_fit_flag | SwapiL3Flags.BAD_FIT)
 
     fit_r_squared = _alpha_r_squared(

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -33,7 +33,10 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.uncertainties import (
 from imap_l3_processing.swapi.quality_flags import SwapiL3Flags
 from imap_l3_processing.swapi.response.deadtime import deadtime_factor
 
-MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO = 1.7
+# reject alpha fits where the speed is less than 90% of
+# the proton speed, to avoid cases where the proton shoulder
+# is confused for the alpha population
+TOLERABLE_ALPHA_SPEED_RATIO = 0.9
 
 
 @dataclass
@@ -162,7 +165,8 @@ def _construct_alpha_fit_result(
         np.linalg.norm(velocity_rtn, axis=-1)
         / np.linalg.norm(proton_bulk, axis=-1)
     ) ** 2
-    if peak_energy_ratio < MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO:
+    # convert energy-per-charge to speed for comparison
+    if np.sqrt(peak_energy_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E) < TOLERABLE_ALPHA_SPEED_RATIO:
         return _nan_alpha_fit_result(bad_fit_flag | SwapiL3Flags.BAD_FIT)
 
     fit_r_squared = _alpha_r_squared(

--- a/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
+++ b/imap_l3_processing/swapi/l3a/science/solar_wind/alpha/fit_solar_wind_alpha_model.py
@@ -6,6 +6,7 @@ import scipy.optimize
 from numpy import ndarray
 from uncertainties import UFloat, covariance_matrix, ufloat
 
+from imap_l3_processing.constants import ALPHA_MASS_PER_CHARGE_M_P_PER_E
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.calculate_initial_guess import (
     calculate_initial_guess,
 )
@@ -157,7 +158,7 @@ def _construct_alpha_fit_result(
     delta_v_fit = float(result.x[2])
     velocity_rtn = proton_bulk + delta_v_fit * magnetic_field_direction
 
-    peak_energy_ratio = 2 * (
+    peak_energy_ratio = ALPHA_MASS_PER_CHARGE_M_P_PER_E * (
         np.linalg.norm(velocity_rtn) / np.linalg.norm(proton_bulk)
     ) ** 2
     if (

--- a/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
+++ b/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
@@ -18,7 +18,7 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.alpha import (
     calculate_initial_guess as alpha_initial_guess_module,
 )
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.fit_solar_wind_alpha_model import (
-    MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO,
+    TOLERABLE_ALPHA_SPEED_RATIO,
     AlphaSolarWindFitResult,
     _AlphaEvaluator,
     fit_solar_wind_alpha_model,
@@ -407,20 +407,18 @@ class TestFitAlphaMomentsRecoversTruth(
 class TestAlphaPeakEnergyRatioGuard(
     _SyntheticAlphaSpectrumFixture, unittest.TestCase
 ):
-    """Only fitted alpha peaks below the minimum energy ratio are rejected."""
+    """Only fitted alpha speeds below the tolerable ratio to the proton speed are rejected."""
 
-    def test_peak_energy_ratio_has_a_lower_bound_but_no_upper_bound(self):
+    def test_alpha_speed_ratio_has_a_lower_bound_but_no_upper_bound(self):
         proton_speed = np.linalg.norm(_TRUE_PROTON_VELOCITY_RTN)
         cases = (
-            (MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO - 0.01, SwapiL3Flags.BAD_FIT),
-            (2.4, SwapiL3Flags.NONE),
+            (TOLERABLE_ALPHA_SPEED_RATIO - 0.01, SwapiL3Flags.BAD_FIT),
+            (1.1, SwapiL3Flags.NONE),
         )
 
-        for peak_energy_ratio, expected_flag in cases:
-            with self.subTest(peak_energy_ratio=peak_energy_ratio):
-                alpha_speed = proton_speed * np.sqrt(
-                    peak_energy_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E
-                )
+        for alpha_speed_ratio, expected_flag in cases:
+            with self.subTest(alpha_speed_ratio=alpha_speed_ratio):
+                alpha_speed = proton_speed * alpha_speed_ratio
                 observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
                     response=self.response,
                     voltage=self.voltage,

--- a/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
+++ b/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
@@ -19,6 +19,7 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.alpha import (
 )
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.fit_solar_wind_alpha_model import (
     MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO,
+    MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO,
     AlphaSolarWindFitResult,
     _AlphaEvaluator,
     fit_solar_wind_alpha_model,
@@ -409,34 +410,40 @@ class TestAlphaPeakEnergyRatioGuard(
 ):
     """Fitted alpha peaks outside the configured ratio range are rejected."""
 
-    def test_out_of_range_fitted_alpha_peak_returns_bad_fit(self):
+    def test_out_of_range_fitted_alpha_peaks_return_bad_fit(self):
         proton_speed = np.linalg.norm(_TRUE_PROTON_VELOCITY_RTN)
-        out_of_range_ratio = MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO + 0.2
-        alpha_speed = proton_speed * np.sqrt(
-            out_of_range_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E
-        )
-        observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
-            response=self.response,
-            voltage=self.voltage,
-            rotation_matrices=self.rotation_matrices,
-            delta_v=alpha_speed - proton_speed,
-        )
-        proton_ctx, alpha_ctx = _build_proton_and_alpha_contexts(
-            response=self.response,
-            count_rate=observed,
-            voltage=self.voltage,
-            rotation_matrices=self.rotation_matrices,
+        out_of_range_ratios = (
+            MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO - 0.1,
+            MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO + 0.1,
         )
 
-        result = fit_solar_wind_alpha_model(
-            proton_ctx=proton_ctx,
-            alpha_ctx=alpha_ctx,
-            proton_moments=_build_proton_fit_result(),
-            magnetic_field_direction=_B_HAT_RTN,
-        )
+        for out_of_range_ratio in out_of_range_ratios:
+            with self.subTest(peak_energy_ratio=out_of_range_ratio):
+                alpha_speed = proton_speed * np.sqrt(
+                    out_of_range_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E
+                )
+                observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
+                    response=self.response,
+                    voltage=self.voltage,
+                    rotation_matrices=self.rotation_matrices,
+                    delta_v=alpha_speed - proton_speed,
+                )
+                proton_ctx, alpha_ctx = _build_proton_and_alpha_contexts(
+                    response=self.response,
+                    count_rate=observed,
+                    voltage=self.voltage,
+                    rotation_matrices=self.rotation_matrices,
+                )
 
-        self.assertEqual(result.quality_flag, int(SwapiL3Flags.BAD_FIT))
-        _assert_moments_are_nan_filled(self, result)
+                result = fit_solar_wind_alpha_model(
+                    proton_ctx=proton_ctx,
+                    alpha_ctx=alpha_ctx,
+                    proton_moments=_build_proton_fit_result(),
+                    magnetic_field_direction=_B_HAT_RTN,
+                )
+
+                self.assertEqual(result.quality_flag, int(SwapiL3Flags.BAD_FIT))
+                _assert_moments_are_nan_filled(self, result)
 
 
 class TestFitAlphaMomentsAlphaVelocityFollowsBHat(unittest.TestCase):

--- a/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
+++ b/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
@@ -18,6 +18,7 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.alpha import (
     calculate_initial_guess as alpha_initial_guess_module,
 )
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.fit_solar_wind_alpha_model import (
+    MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO,
     AlphaSolarWindFitResult,
     _AlphaEvaluator,
     fit_solar_wind_alpha_model,
@@ -401,6 +402,41 @@ class TestFitAlphaMomentsRecoversTruth(
             self.alpha_velocity_rtn,
             atol=1.0,
         )
+
+
+class TestAlphaPeakEnergyRatioGuard(
+    _SyntheticAlphaSpectrumFixture, unittest.TestCase
+):
+    """Fitted alpha peaks outside the configured ratio range are rejected."""
+
+    def test_out_of_range_fitted_alpha_peak_returns_bad_fit(self):
+        proton_speed = np.linalg.norm(_TRUE_PROTON_VELOCITY_RTN)
+        out_of_range_ratio = MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO + 0.2
+        alpha_speed = proton_speed * np.sqrt(
+            out_of_range_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E
+        )
+        observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
+            response=self.response,
+            voltage=self.voltage,
+            rotation_matrices=self.rotation_matrices,
+            delta_v=alpha_speed - proton_speed,
+        )
+        proton_ctx, alpha_ctx = _build_proton_and_alpha_contexts(
+            response=self.response,
+            count_rate=observed,
+            voltage=self.voltage,
+            rotation_matrices=self.rotation_matrices,
+        )
+
+        result = fit_solar_wind_alpha_model(
+            proton_ctx=proton_ctx,
+            alpha_ctx=alpha_ctx,
+            proton_moments=_build_proton_fit_result(),
+            magnetic_field_direction=_B_HAT_RTN,
+        )
+
+        self.assertEqual(result.quality_flag, int(SwapiL3Flags.BAD_FIT))
+        _assert_moments_are_nan_filled(self, result)
 
 
 class TestFitAlphaMomentsAlphaVelocityFollowsBHat(unittest.TestCase):

--- a/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
+++ b/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
@@ -18,7 +18,6 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.alpha import (
     calculate_initial_guess as alpha_initial_guess_module,
 )
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.fit_solar_wind_alpha_model import (
-    MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO,
     MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO,
     AlphaSolarWindFitResult,
     _AlphaEvaluator,
@@ -408,19 +407,19 @@ class TestFitAlphaMomentsRecoversTruth(
 class TestAlphaPeakEnergyRatioGuard(
     _SyntheticAlphaSpectrumFixture, unittest.TestCase
 ):
-    """Fitted alpha peaks outside the configured ratio range are rejected."""
+    """Only fitted alpha peaks below the minimum energy ratio are rejected."""
 
-    def test_out_of_range_fitted_alpha_peaks_return_bad_fit(self):
+    def test_peak_energy_ratio_has_a_lower_bound_but_no_upper_bound(self):
         proton_speed = np.linalg.norm(_TRUE_PROTON_VELOCITY_RTN)
-        out_of_range_ratios = (
-            MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO - 0.1,
-            MAX_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO + 0.1,
+        cases = (
+            (MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO - 0.1, SwapiL3Flags.BAD_FIT),
+            (2.4, SwapiL3Flags.NONE),
         )
 
-        for out_of_range_ratio in out_of_range_ratios:
-            with self.subTest(peak_energy_ratio=out_of_range_ratio):
+        for peak_energy_ratio, expected_flag in cases:
+            with self.subTest(peak_energy_ratio=peak_energy_ratio):
                 alpha_speed = proton_speed * np.sqrt(
-                    out_of_range_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E
+                    peak_energy_ratio / ALPHA_MASS_PER_CHARGE_M_P_PER_E
                 )
                 observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
                     response=self.response,
@@ -442,8 +441,11 @@ class TestAlphaPeakEnergyRatioGuard(
                     magnetic_field_direction=_B_HAT_RTN,
                 )
 
-                self.assertEqual(result.quality_flag, int(SwapiL3Flags.BAD_FIT))
-                _assert_moments_are_nan_filled(self, result)
+                self.assertEqual(result.quality_flag, int(expected_flag))
+                if expected_flag == SwapiL3Flags.BAD_FIT:
+                    _assert_moments_are_nan_filled(self, result)
+                else:
+                    self.assertTrue(np.isfinite(result.density.nominal_value))
 
 
 class TestFitAlphaMomentsAlphaVelocityFollowsBHat(unittest.TestCase):

--- a/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
+++ b/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
@@ -18,7 +18,7 @@ from imap_l3_processing.swapi.l3a.science.solar_wind.alpha import (
     calculate_initial_guess as alpha_initial_guess_module,
 )
 from imap_l3_processing.swapi.l3a.science.solar_wind.alpha.fit_solar_wind_alpha_model import (
-    TOLERABLE_ALPHA_SPEED_RATIO,
+    MIN_TOLERABLE_ALPHA_SPEED_RATIO,
     AlphaSolarWindFitResult,
     _AlphaEvaluator,
     fit_solar_wind_alpha_model,
@@ -409,41 +409,33 @@ class TestAlphaPeakEnergyRatioGuard(
 ):
     """Only fitted alpha speeds below the tolerable ratio to the proton speed are rejected."""
 
-    def test_alpha_speed_ratio_has_a_lower_bound_but_no_upper_bound(self):
+    def test_alpha_speed_ratio_lower_bound(self):
+        bad_alpha_speed_ratio = MIN_TOLERABLE_ALPHA_SPEED_RATIO - 0.01
+
         proton_speed = np.linalg.norm(_TRUE_PROTON_VELOCITY_RTN)
-        cases = (
-            (TOLERABLE_ALPHA_SPEED_RATIO - 0.01, SwapiL3Flags.BAD_FIT),
-            (1.1, SwapiL3Flags.NONE),
+        alpha_speed = proton_speed * bad_alpha_speed_ratio
+        observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
+            response=self.response,
+            voltage=self.voltage,
+            rotation_matrices=self.rotation_matrices,
+            delta_v=alpha_speed - proton_speed,
+        )
+        proton_ctx, alpha_ctx = _build_proton_and_alpha_contexts(
+            response=self.response,
+            count_rate=observed,
+            voltage=self.voltage,
+            rotation_matrices=self.rotation_matrices,
         )
 
-        for alpha_speed_ratio, expected_flag in cases:
-            with self.subTest(alpha_speed_ratio=alpha_speed_ratio):
-                alpha_speed = proton_speed * alpha_speed_ratio
-                observed, _, _ = _synthesize_proton_plus_alpha_count_rate(
-                    response=self.response,
-                    voltage=self.voltage,
-                    rotation_matrices=self.rotation_matrices,
-                    delta_v=alpha_speed - proton_speed,
-                )
-                proton_ctx, alpha_ctx = _build_proton_and_alpha_contexts(
-                    response=self.response,
-                    count_rate=observed,
-                    voltage=self.voltage,
-                    rotation_matrices=self.rotation_matrices,
-                )
+        result = fit_solar_wind_alpha_model(
+            proton_ctx=proton_ctx,
+            alpha_ctx=alpha_ctx,
+            proton_moments=_build_proton_fit_result(),
+            magnetic_field_direction=_B_HAT_RTN,
+        )
 
-                result = fit_solar_wind_alpha_model(
-                    proton_ctx=proton_ctx,
-                    alpha_ctx=alpha_ctx,
-                    proton_moments=_build_proton_fit_result(),
-                    magnetic_field_direction=_B_HAT_RTN,
-                )
-
-                self.assertEqual(result.quality_flag, int(expected_flag))
-                if expected_flag == SwapiL3Flags.BAD_FIT:
-                    _assert_moments_are_nan_filled(self, result)
-                else:
-                    self.assertTrue(np.isfinite(result.density.nominal_value))
+        self.assertEqual(result.quality_flag, int(SwapiL3Flags.BAD_FIT))
+        _assert_moments_are_nan_filled(self, result)
 
 
 class TestFitAlphaMomentsAlphaVelocityFollowsBHat(unittest.TestCase):

--- a/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
+++ b/tests/swapi/l3a/science/solar_wind/alpha/test_fit_solar_wind_alpha_model.py
@@ -412,7 +412,7 @@ class TestAlphaPeakEnergyRatioGuard(
     def test_peak_energy_ratio_has_a_lower_bound_but_no_upper_bound(self):
         proton_speed = np.linalg.norm(_TRUE_PROTON_VELOCITY_RTN)
         cases = (
-            (MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO - 0.1, SwapiL3Flags.BAD_FIT),
+            (MIN_ALPHA_TO_PROTON_PEAK_ENERGY_RATIO - 0.01, SwapiL3Flags.BAD_FIT),
             (2.4, SwapiL3Flags.NONE),
         )
 


### PR DESCRIPTION
# Change Summary

Closes #146.

## Overview

Flag alpha solar-wind fits as `BAD_FIT` when the approximate fitted alpha-to-proton peak energy ratio is below 1.7. Calculate the ratio analytically from the fitted bulk velocity magnitudes, without evaluating additional model-rate curves.

## File changes

- `fit_solar_wind_alpha_model.py`: Calculate the approximate peak-energy ratio as $2|v_\alpha|^2/|v_p|^2$ and flag ratios below 1.7 as `BAD_FIT`.
- `test_fit_solar_wind_alpha_model.py`: Verify that ratios below 1.7 are rejected.
- `alpha-sw.md`: Document the explicit 1.7 lower threshold.

## Testing

The focused alpha-fit unit test suite passes:
```shell
uv run python -m unittest \
    tests.swapi.l3a.science.solar_wind.alpha.test_fit_solar_wind_alpha_model
```
results in:
```text
..............................
----------------------------------------------------------------------
Ran 30 tests

OK
```